### PR TITLE
Improve robustness to make sure input parameters are valid

### DIFF
--- a/src/main/java/uk/co/ramp/distribution/Distribution.java
+++ b/src/main/java/uk/co/ramp/distribution/Distribution.java
@@ -1,6 +1,8 @@
 package uk.co.ramp.distribution;
 
+import com.google.common.base.Preconditions;
 import org.immutables.gson.Gson.TypeAdapters;
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
 @TypeAdapters
@@ -9,4 +11,11 @@ public interface Distribution {
     ProgressionDistribution type();
     double mean();
     double max();
+
+    @Check
+    default void check() {
+        Preconditions.checkState(mean() <= max(), "Mean should be less than or equal to max");
+        Preconditions.checkState(mean() >= 0, "Mean should not be negative");
+        Preconditions.checkState(max() >= 0, "Max should not be negative");
+    }
 }

--- a/src/main/java/uk/co/ramp/io/types/DiseaseProperties.java
+++ b/src/main/java/uk/co/ramp/io/types/DiseaseProperties.java
@@ -1,6 +1,8 @@
 package uk.co.ramp.io.types;
 
+import com.google.common.base.Preconditions;
 import org.immutables.gson.Gson.TypeAdapters;
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 import uk.co.ramp.distribution.ProgressionDistribution;
 import uk.co.ramp.utilities.MeanMax;
@@ -36,4 +38,11 @@ public interface DiseaseProperties {
     double exposureThreshold();
 
     ProgressionDistribution progressionDistribution();
+
+    @Check
+    default void check() {
+        Preconditions.checkState(testAccuracy() >= 0 && testAccuracy() <= 1, "Test accuracy should be between 0 and 1");
+        Preconditions.checkState(randomInfectionRate() >= 0 && randomInfectionRate() <= 1, "Random infection rate should be between 0 and 1");
+        Preconditions.checkState(exposureTuning() >= 0, "Exposure tuning value should be positive");
+    }
 }

--- a/src/main/java/uk/co/ramp/io/types/InputFiles.java
+++ b/src/main/java/uk/co/ramp/io/types/InputFiles.java
@@ -1,6 +1,8 @@
 package uk.co.ramp.io.types;
 
+import com.google.common.base.Preconditions;
 import org.immutables.gson.Gson.TypeAdapters;
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
 @TypeAdapters
@@ -17,4 +19,12 @@ public interface InputFiles {
 
     String initialExposures();
 
+    @Check
+    default void check() {
+        Preconditions.checkState(!runSettings().isBlank(), "Run settings location should not be blank");
+        Preconditions.checkState(!populationSettings().isBlank(), "Population settings location should not be blank");
+        Preconditions.checkState(!diseaseSettings().isBlank(), "Disease settings location should not be blank");
+        Preconditions.checkState(!contactData().isBlank(), "Contact data location should not be blank");
+        Preconditions.checkState(!initialExposures().isBlank(), "Initial exposure data location should not be blank");
+    }
 }

--- a/src/main/java/uk/co/ramp/io/types/PopulationProperties.java
+++ b/src/main/java/uk/co/ramp/io/types/PopulationProperties.java
@@ -1,10 +1,13 @@
 package uk.co.ramp.io.types;
 
+import com.google.common.base.Preconditions;
 import org.immutables.gson.Gson.TypeAdapters;
 import org.immutables.value.Value.Immutable;
 import uk.co.ramp.utilities.MinMax;
 
 import java.util.Map;
+
+import static org.immutables.value.Value.Check;
 
 @TypeAdapters
 @Immutable
@@ -12,4 +15,11 @@ public interface PopulationProperties {
     Map<Integer, Double> populationDistribution();
     Map<Integer, MinMax> populationAges();
     double genderBalance();
+
+    @Check
+    default void check() {
+        Preconditions.checkState(populationDistribution().values().stream().mapToDouble(d -> d).sum() == 1, "Sum of population distribution should be 1");
+        Preconditions.checkState(populationDistribution().keySet().equals(populationAges().keySet()), "Bins should be consistent");
+        Preconditions.checkState(genderBalance() >= 0 && genderBalance() <= 1, "Gender balance should be between 0 and 1");
+    }
 }

--- a/src/main/java/uk/co/ramp/io/types/StandardProperties.java
+++ b/src/main/java/uk/co/ramp/io/types/StandardProperties.java
@@ -1,6 +1,8 @@
 package uk.co.ramp.io.types;
 
+import com.google.common.base.Preconditions;
 import org.immutables.gson.Gson.TypeAdapters;
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
 @TypeAdapters
@@ -14,4 +16,10 @@ public interface StandardProperties {
     int seed();
     boolean steadyState();
 
+    @Check
+    default void check() {
+        Preconditions.checkState(populationSize() > 0, "Population size should be greater than 0");
+        Preconditions.checkState(timeLimit() >= 0, "Time limit should not be negative");
+        Preconditions.checkState(initialExposures() >= 0, "Initial exposures should not be negative");
+    }
 }

--- a/src/main/java/uk/co/ramp/policy/IsolationProperty.java
+++ b/src/main/java/uk/co/ramp/policy/IsolationProperty.java
@@ -1,6 +1,9 @@
 package uk.co.ramp.policy;
 
+import com.google.common.base.Preconditions;
 import org.immutables.gson.Gson.TypeAdapters;
+import org.immutables.value.Value;
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 import uk.co.ramp.distribution.Distribution;
 
@@ -13,4 +16,9 @@ interface IsolationProperty {
     Distribution isolationProbabilityDistribution();
     Optional<Distribution> isolationTimeDistribution();
     int priority();
+
+    @Check
+    default void check() {
+        Preconditions.checkState(!id().isBlank(), "id should not be blank");
+    }
 }

--- a/src/main/java/uk/co/ramp/utilities/MeanMax.java
+++ b/src/main/java/uk/co/ramp/utilities/MeanMax.java
@@ -2,7 +2,9 @@ package uk.co.ramp.utilities;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Preconditions;
 import org.immutables.gson.Gson.TypeAdapters;
+import org.immutables.value.Value.Check;
 import org.immutables.value.Value.Immutable;
 
 @TypeAdapters
@@ -13,4 +15,11 @@ public interface MeanMax {
     int mean();
 
     int max();
+
+    @Check
+    default void check() {
+        Preconditions.checkState(mean() >= 0, "Mean should not be negative");
+        Preconditions.checkState(max() >= 0, "Max should not be negative");
+        Preconditions.checkState(mean() <= max(), "Mean should be less than or equal to max");
+    }
 }

--- a/src/main/java/uk/co/ramp/utilities/MinMax.java
+++ b/src/main/java/uk/co/ramp/utilities/MinMax.java
@@ -1,6 +1,8 @@
 package uk.co.ramp.utilities;
 
+import com.google.common.base.Preconditions;
 import org.immutables.gson.Gson.TypeAdapters;
+import org.immutables.value.Value;
 import org.immutables.value.Value.Immutable;
 
 @TypeAdapters
@@ -14,5 +16,10 @@ public abstract class MinMax {
                 .min(Math.min(a, b))
                 .max(Math.max(a, b))
                 .build();
+    }
+
+    @Value.Check
+    protected void check() {
+        Preconditions.checkState(min() <= max(), "Min should be less than or equal to max");
     }
 }


### PR DESCRIPTION
Improve robustness to make sure input parameters are valid. This will be useful for when Rikiya/Fedor carry out inference work on our model. This will make sure inappropriate parameter values are not explored.