### PR TITLE
Splitting up EventList (refactor PR - no functional changes)

### DIFF
--- a/src/main/java/uk/co/ramp/ContactRunner.java
+++ b/src/main/java/uk/co/ramp/ContactRunner.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
-import uk.co.ramp.event.EventList;
+import uk.co.ramp.event.EventListGroup;
 import uk.co.ramp.io.CompartmentWriter;
 import uk.co.ramp.io.ContactReader;
 import uk.co.ramp.io.csv.CsvException;
@@ -43,9 +43,9 @@ public class ContactRunner implements CommandLineRunner {
         try (Reader reader = new FileReader(inputFileLocation.contactData())) {
 
             ContactReader contactReader = ctx.getBean(ContactReader.class);
-            EventList eventList = ctx.getBean(EventList.class);
+            EventListGroup eventListGroup = ctx.getBean(EventListGroup.class);
 
-            eventList.addEvents(contactReader.readEvents(reader));
+            eventListGroup.addContactEvents(contactReader.readEvents(reader));
 
             LOGGER.info("Generated Population and Parsed Contact data");
 

--- a/src/main/java/uk/co/ramp/event/AlertEventProcessor.java
+++ b/src/main/java/uk/co/ramp/event/AlertEventProcessor.java
@@ -1,18 +1,12 @@
-package uk.co.ramp.event.processor;
+package uk.co.ramp.event;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 import uk.co.ramp.Population;
 import uk.co.ramp.distribution.Distribution;
 import uk.co.ramp.distribution.DistributionSampler;
 import uk.co.ramp.distribution.ImmutableDistribution;
-import uk.co.ramp.event.EventException;
-import uk.co.ramp.event.types.AlertEvent;
-import uk.co.ramp.event.types.ImmutableAlertEvent;
-import uk.co.ramp.event.types.ImmutableProcessedEventResult;
-import uk.co.ramp.event.types.ProcessedEventResult;
+import uk.co.ramp.event.types.*;
 import uk.co.ramp.io.types.DiseaseProperties;
 import uk.co.ramp.people.AlertStatus;
 import uk.co.ramp.people.Case;
@@ -24,7 +18,6 @@ import java.util.List;
 import static uk.co.ramp.people.AlertStatus.*;
 import static uk.co.ramp.people.AlertStatus.NONE;
 
-@Service
 public class AlertEventProcessor implements EventProcessor<AlertEvent> {
     private static final Logger LOGGER = LogManager.getLogger(AlertEventProcessor.class);
 
@@ -32,7 +25,6 @@ public class AlertEventProcessor implements EventProcessor<AlertEvent> {
     private final DiseaseProperties diseaseProperties;
     private final DistributionSampler distributionSampler;
 
-    @Autowired
     public AlertEventProcessor(Population population, DiseaseProperties diseaseProperties, DistributionSampler distributionSampler) {
         this.population = population;
         this.diseaseProperties = diseaseProperties;
@@ -55,12 +47,11 @@ public class AlertEventProcessor implements EventProcessor<AlertEvent> {
                     oldStatus(event.nextStatus()).
                     nextStatus(nextStatus).
                     time(event.time() + deltaTime).
-                    eventProcessor(this).
                     build();
 
             return ImmutableProcessedEventResult.builder()
-                    .addNewEvents(subsequentEvent)
-                    .completedEvent(event)
+                    .addNewAlertEvents(subsequentEvent)
+                    .addCompletedEvents(event)
                     .build();
         }
         return ImmutableProcessedEventResult.builder().build();

--- a/src/main/java/uk/co/ramp/event/CommonVirusEventProcessor.java
+++ b/src/main/java/uk/co/ramp/event/CommonVirusEventProcessor.java
@@ -1,4 +1,4 @@
-package uk.co.ramp.event.processor;
+package uk.co.ramp.event;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -6,9 +6,9 @@ import uk.co.ramp.Population;
 import uk.co.ramp.distribution.Distribution;
 import uk.co.ramp.distribution.DistributionSampler;
 import uk.co.ramp.distribution.ImmutableDistribution;
-import uk.co.ramp.event.EventException;
 import uk.co.ramp.event.types.CommonVirusEvent;
 import uk.co.ramp.event.types.Event;
+import uk.co.ramp.event.types.EventProcessor;
 import uk.co.ramp.io.types.DiseaseProperties;
 import uk.co.ramp.people.Case;
 import uk.co.ramp.people.VirusStatus;

--- a/src/main/java/uk/co/ramp/event/EventContext.java
+++ b/src/main/java/uk/co/ramp/event/EventContext.java
@@ -1,0 +1,53 @@
+package uk.co.ramp.event;
+
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.context.annotation.Bean;
+import uk.co.ramp.Population;
+import uk.co.ramp.distribution.DistributionSampler;
+import uk.co.ramp.event.types.*;
+import uk.co.ramp.io.InitialCaseReader;
+import uk.co.ramp.io.types.DiseaseProperties;
+import uk.co.ramp.policy.IsolationPolicy;
+
+@SpringBootConfiguration
+public class EventContext {
+    private final EventList<Event> completedEventList = new EventList<>();
+
+    @Bean
+    public EventListGroup eventListGroup() {
+        EventList<AlertEvent> alertEventList = new EventList<>();
+        EventList<ContactEvent> contactEventList = new EventList<>();
+        EventList<InfectionEvent> infectionEventList = new EventList<>();
+        EventList<VirusEvent> virusEventList = new EventList<>();
+        return new EventListGroup(alertEventList, contactEventList, infectionEventList, virusEventList, completedEventList);
+    }
+
+    @Bean
+    public EventRunner eventRunner(Population population, DiseaseProperties diseaseProperties, DistributionSampler distributionSampler, IsolationPolicy isolationPolicy, InitialCaseReader initialCaseReader, EventListGroup eventListGroup) {
+        AlertEventProcessor alertEventProcessor = new AlertEventProcessor(population, diseaseProperties, distributionSampler);
+        VirusEventProcessor virusEventProcessor = new VirusEventProcessor(population, diseaseProperties, distributionSampler);
+        InfectionEventProcessor infectionEventProcessor = new InfectionEventProcessor(population, diseaseProperties, distributionSampler);
+        ContactEventProcessor contactEventProcessor = new ContactEventProcessor(population, diseaseProperties, distributionSampler, isolationPolicy);
+
+        ProcessedEventsGrouper processedEventsGrouper = new ProcessedEventsGrouper();
+
+        EventProcessorRunner<AlertEvent> alertEventRunner = new EventProcessorRunner<>(alertEventProcessor, processedEventsGrouper);
+        EventProcessorRunner<ContactEvent> contactEventRunner = new EventProcessorRunner<>(contactEventProcessor, processedEventsGrouper);
+        EventProcessorRunner<InfectionEvent> infectionEventRunner = new EventProcessorRunner<>(infectionEventProcessor, processedEventsGrouper);
+        EventProcessorRunner<VirusEvent> virusEventRunner = new EventProcessorRunner<>(virusEventProcessor, processedEventsGrouper);
+
+        InfectionCreator infectionCreator = new InfectionCreator(population, distributionSampler, initialCaseReader);
+        return new EventRunnerImpl(alertEventRunner, contactEventRunner, infectionEventRunner, virusEventRunner, processedEventsGrouper, infectionCreator, eventListGroup);
+    }
+
+    @Bean
+    public EventListWriter eventListWriter() {
+        FormattedEventFactory formattedEventFactory = new FormattedEventFactory();
+        return new EventListWriter(formattedEventFactory, completedEventList);
+    }
+
+    @Bean
+    public LastContactTime lastContactTime(EventListGroup eventListGroup) {
+        return new LastContactTime(eventListGroup);
+    }
+}

--- a/src/main/java/uk/co/ramp/event/EventList.java
+++ b/src/main/java/uk/co/ramp/event/EventList.java
@@ -1,79 +1,29 @@
 package uk.co.ramp.event;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Repository;
-import uk.co.ramp.event.types.ContactEvent;
 import uk.co.ramp.event.types.Event;
-import uk.co.ramp.event.types.ImmutableFormattedEvent;
-import uk.co.ramp.io.csv.CsvException;
-import uk.co.ramp.io.csv.CsvWriter;
 
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.Writer;
 import java.util.*;
-import java.util.stream.Collectors;
 
-@Repository
-public class EventList {
-
-    public static final String EVENTS_CSV = "events.csv";
-    private final Map<Integer, List<Event>> map = new HashMap<>();
-    private final Map<Integer, List<Event>> completedMap = new HashMap<>();
-    private final FormattedEventFactory formattedEventFactory;
-
-    private static final Logger LOGGER = LogManager.getLogger(EventList.class);
-
-    @Autowired
-    public EventList(FormattedEventFactory formattedEventFactory) {
-        this.formattedEventFactory = formattedEventFactory;
-    }
+public class EventList<T extends Event> {
+    private final Map<Integer, List<T>> map = new HashMap<>();
 
     //create
-    public void addEvent(Event e) {
+    public void addEvent(T e) {
         map.computeIfAbsent(e.time(), k -> new ArrayList<>()).add(e);
     }
 
-    public void addEvents(List<Event> events) {
+    public void addEvents(List<T> events) {
         events.forEach(this::addEvent);
     }
 
-    public void addEvents(Map<Integer, List<ContactEvent>> readEvents) {
-        readEvents.values().stream().flatMap(List::stream).forEach(this::addEvent);
-    }
-
-    public void completed(Event e) {
-        completedMap.computeIfAbsent(e.time(), k -> new ArrayList<>()).add(e);
-    }
-
-
     //read
-    List<Event> getForTime(int time) {
-        return map.getOrDefault(time, new ArrayList<>());
+    public List<T> getForTime(int time) {
+        return Collections.unmodifiableList(map.getOrDefault(time, List.of()));
     }
 
-
-    public void output() {
-
-        List<Integer> timeStamps = new ArrayList<>(completedMap.keySet());
-        timeStamps.sort(Comparator.naturalOrder());
-        List<ImmutableFormattedEvent> finalList = timeStamps.stream().map(completedMap::get).flatMap(Collection::stream).map(formattedEventFactory::create).filter(Objects::nonNull).collect(Collectors.toList());
-
-        try (Writer writer = new FileWriter(EVENTS_CSV)) {
-            new CsvWriter().write(writer, finalList, ImmutableFormattedEvent.class);
-
-        } catch (IOException e) {
-            String message = "An error occurred while writing a CSV file";
-            LOGGER.error(message);
-            throw new CsvException(message, e);
-        }
-
+    public int lastEventTime() {
+        return map.keySet().stream().mapToInt(i -> i).max().orElseThrow();
     }
 
-    public Optional<Integer> lastContactTime() {
-        return map.keySet().stream().max(Comparator.naturalOrder());
-    }
 
 }

--- a/src/main/java/uk/co/ramp/event/EventListGroup.java
+++ b/src/main/java/uk/co/ramp/event/EventListGroup.java
@@ -1,0 +1,61 @@
+package uk.co.ramp.event;
+
+import uk.co.ramp.event.types.*;
+
+import java.util.*;
+
+public class EventListGroup {
+    private final EventList<AlertEvent> alertEvents;
+    private final EventList<ContactEvent> contactEvents;
+    private final EventList<InfectionEvent> infectionEvents;
+    private final EventList<VirusEvent> virusEvents;
+    private final EventList<Event> completedEvents;
+
+    EventListGroup(EventList<AlertEvent> alertEvents, EventList<ContactEvent> contactEvents, EventList<InfectionEvent> infectionEvents, EventList<VirusEvent> virusEvents, EventList<Event> completedEvents) {
+        this.alertEvents = alertEvents;
+        this.contactEvents = contactEvents;
+        this.infectionEvents = infectionEvents;
+        this.virusEvents = virusEvents;
+        this.completedEvents = completedEvents;
+    }
+
+    public void addContactEvents(List<ContactEvent> events) {
+        contactEvents.addEvents(events);
+    }
+
+    public void addInfectionEvents(List<InfectionEvent> events) {
+        infectionEvents.addEvents(events);
+    }
+
+    public void addAlertEvents(List<AlertEvent> events) {
+        alertEvents.addEvents(events);
+    }
+
+    public void addVirusEvents(List<VirusEvent> events) {
+        virusEvents.addEvents(events);
+    }
+
+    public void completed(List<Event> e) {
+        completedEvents.addEvents(e);
+    }
+
+    public List<ContactEvent> getContactEvents(int time) {
+        return Collections.unmodifiableList(contactEvents.getForTime(time));
+    }
+
+    public List<AlertEvent> getAlertEvents(int time) {
+        return Collections.unmodifiableList(alertEvents.getForTime(time));
+    }
+
+    public List<InfectionEvent> getInfectionEvents(int time) {
+        return Collections.unmodifiableList(infectionEvents.getForTime(time));
+    }
+
+    public List<VirusEvent> getVirusEvents(int time) {
+        return Collections.unmodifiableList(virusEvents.getForTime(time));
+    }
+
+    public int lastContactTime() {
+        return contactEvents.lastEventTime();
+    }
+}

--- a/src/main/java/uk/co/ramp/event/EventListWriter.java
+++ b/src/main/java/uk/co/ramp/event/EventListWriter.java
@@ -1,0 +1,53 @@
+package uk.co.ramp.event;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.co.ramp.event.types.Event;
+import uk.co.ramp.event.types.ImmutableFormattedEvent;
+import uk.co.ramp.io.csv.CsvException;
+import uk.co.ramp.io.csv.CsvWriter;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class EventListWriter {
+    public static final String EVENTS_CSV = "events.csv";
+    private static final Logger LOGGER = LogManager.getLogger(EventListWriter.class);
+
+    private final FormattedEventFactory formattedEventFactory;
+    private final EventList<Event> completedEvents;
+
+    EventListWriter(FormattedEventFactory formattedEventFactory, EventList<Event> completedEvents) {
+        this.formattedEventFactory = formattedEventFactory;
+        this.completedEvents = completedEvents;
+    }
+
+    public void output() {
+        Map<Integer, List<Event>> completedMap = IntStream.rangeClosed(0, completedEvents.lastEventTime()).boxed()
+                .collect(Collectors.toMap(Function.identity(), completedEvents::getForTime));
+
+        List<Integer> timeStamps = new ArrayList<>(completedMap.keySet());
+        timeStamps.sort(Comparator.naturalOrder());
+        List<ImmutableFormattedEvent> finalList = timeStamps.stream()
+                .map(completedMap::get)
+                .flatMap(Collection::stream)
+                .map(formattedEventFactory::create)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        try (Writer writer = new FileWriter(EVENTS_CSV)) {
+            new CsvWriter().write(writer, finalList, ImmutableFormattedEvent.class);
+
+        } catch (IOException e) {
+            String message = "An error occurred while writing a CSV file";
+            LOGGER.error(message);
+            throw new CsvException(message, e);
+        }
+
+    }
+}

--- a/src/main/java/uk/co/ramp/event/EventProcessorRunner.java
+++ b/src/main/java/uk/co/ramp/event/EventProcessorRunner.java
@@ -1,86 +1,26 @@
 package uk.co.ramp.event;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-import uk.co.ramp.Population;
-import uk.co.ramp.distribution.DistributionSampler;
-import uk.co.ramp.event.processor.InfectionEventProcessor;
-import uk.co.ramp.event.types.*;
-import uk.co.ramp.people.Case;
+import uk.co.ramp.event.types.Event;
+import uk.co.ramp.event.types.EventProcessor;
+import uk.co.ramp.event.types.ProcessedEventResult;
 
-import java.util.*;
+import java.util.List;
 import java.util.stream.Collectors;
 
-import static uk.co.ramp.people.VirusStatus.EXPOSED;
-import static uk.co.ramp.people.VirusStatus.SUSCEPTIBLE;
+public class EventProcessorRunner<T extends Event> {
+    private final EventProcessor<T> eventProcessor;
+    private final ProcessedEventsGrouper processedEventsGrouper;
 
-@Service
-public class EventProcessorRunner {
-    private final Population population;
-    private final EventList eventList;
-    private final DistributionSampler distributionSampler;
-    private final InfectionEventProcessor infectionEventProcessor;
-
-    @Autowired
-    public EventProcessorRunner(Population population, DistributionSampler distributionSampler, EventList eventList, InfectionEventProcessor infectionEventProcessor) {
-        this.population = population;
-        this.distributionSampler = distributionSampler;
-        this.eventList = eventList;
-        this.infectionEventProcessor = infectionEventProcessor;
+    public EventProcessorRunner(EventProcessor<T> eventProcessor, ProcessedEventsGrouper processedEventsGrouper) {
+        this.eventProcessor = eventProcessor;
+        this.processedEventsGrouper = processedEventsGrouper;
     }
 
-    public void process(int time, double randomInfectionRate, int randomCutoff) {
-
-        List<Event> newEvents = new ArrayList<>(runAllEvents(time));
-        newEvents.addAll(runPolicyEvents(time));
-
-        if (randomInfectionRate > 0d && time < randomCutoff) {
-            newEvents.addAll(createRandomInfections(time, randomInfectionRate));
-        }
-
-        eventList.addEvents(newEvents);
-
-    }
-
-    List<Event> runAllEvents(int time) {
-        List<ProcessedEventResult> processedEventResults = eventList.getForTime(time).stream()
-                .map(Event::processEvent)
+    public ProcessedEventResult run(List<T> eventsToProcess) {
+        List<ProcessedEventResult> processedEventResults = eventsToProcess.stream()
+                .map(eventProcessor::processEvent)
                 .collect(Collectors.toList());
 
-        processedEventResults.stream()
-                .map(ProcessedEventResult::completedEvent)
-                .flatMap(Optional::stream)
-                .forEach(eventList::completed);
-
-        return processedEventResults.stream()
-                .map(ProcessedEventResult::newEvents)
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
-    }
-
-    List<InfectionEvent> createRandomInfections(int time, double randomRate) {
-
-        List<Case> sus = population.view().values().stream().filter(aCase -> aCase.virusStatus() == SUSCEPTIBLE).collect(Collectors.toList());
-        List<InfectionEvent> randomInfections = new ArrayList<>();
-        for (Case aCase : sus) {
-            if (distributionSampler.uniformBetweenZeroAndOne() < randomRate) {
-                randomInfections.add(
-                        ImmutableInfectionEvent.builder().
-                                time(time + 1).id(aCase.id()).
-                                nextStatus(EXPOSED).
-                                oldStatus(SUSCEPTIBLE).
-                                exposedTime(time).
-                                exposedBy(Case.getRandomInfection()).
-                                eventProcessor(infectionEventProcessor).
-                                build());
-            }
-        }
-
-        return randomInfections;
-    }
-
-    List<Event> runPolicyEvents(int time) {
-        //TODO
-        return new ArrayList<>();
+        return processedEventsGrouper.groupProcessedEventResults(processedEventResults);
     }
 }

--- a/src/main/java/uk/co/ramp/event/EventRunnerImpl.java
+++ b/src/main/java/uk/co/ramp/event/EventRunnerImpl.java
@@ -1,0 +1,63 @@
+package uk.co.ramp.event;
+
+import uk.co.ramp.event.types.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+public class EventRunnerImpl implements EventRunner {
+    private final EventProcessorRunner<AlertEvent> alertEventRunner;
+    private final EventProcessorRunner<ContactEvent> contactEventRunner;
+    private final EventProcessorRunner<InfectionEvent> infectionEventRunner;
+    private final EventProcessorRunner<VirusEvent> virusEventRunner;
+    private final ProcessedEventsGrouper processedEventsGrouper;
+    private final InfectionCreator infectionCreator;
+    private final EventListGroup eventListGroup;
+
+    public EventRunnerImpl(EventProcessorRunner<AlertEvent> alertEventRunner, EventProcessorRunner<ContactEvent> contactEventRunner,
+                           EventProcessorRunner<InfectionEvent> infectionEventRunner, EventProcessorRunner<VirusEvent> virusEventRunner,
+                           ProcessedEventsGrouper processedEventsGrouper, InfectionCreator infectionCreator, EventListGroup eventListGroup) {
+        this.alertEventRunner = alertEventRunner;
+        this.contactEventRunner = contactEventRunner;
+        this.infectionEventRunner = infectionEventRunner;
+        this.virusEventRunner = virusEventRunner;
+        this.processedEventsGrouper = processedEventsGrouper;
+        this.infectionCreator = infectionCreator;
+        this.eventListGroup = eventListGroup;
+    }
+
+    @Override
+    public void run(int time, double randomInfectionRate, double randomCutOff) {
+        List<ProcessedEventResult> processedResults = Stream.of(
+                generateInitialInfection(time),
+                alertEventRunner.run(eventListGroup.getAlertEvents(time)),
+                contactEventRunner.run(eventListGroup.getContactEvents(time)),
+                infectionEventRunner.run(eventListGroup.getInfectionEvents(time)),
+                virusEventRunner.run(eventListGroup.getVirusEvents(time)),
+                createRandomInfections(time, randomInfectionRate, randomCutOff))
+                .collect(Collectors.toList());
+
+        ProcessedEventResult eventResults = processedEventsGrouper.groupProcessedEventResults(processedResults);
+
+        eventListGroup.addContactEvents(eventResults.newContactEvents());
+        eventListGroup.addAlertEvents(eventResults.newAlertEvents());
+        eventListGroup.addInfectionEvents(eventResults.newInfectionEvents());
+        eventListGroup.addVirusEvents(eventResults.newVirusEvents());
+        eventListGroup.completed(eventResults.completedEvents());
+    }
+
+    ProcessedEventResult createRandomInfections(int time, double randomInfectionRate, double randomCutOff) {
+        List<InfectionEvent> randomInfections = infectionCreator.createRandomInfections(time, randomInfectionRate, randomCutOff);
+        return ImmutableProcessedEventResult.builder()
+                .addAllNewInfectionEvents(randomInfections)
+                .build();
+    }
+
+    ProcessedEventResult generateInitialInfection(int time) {
+        return ImmutableProcessedEventResult.builder()
+                .addAllNewInfectionEvents(infectionCreator.generateInitialInfections(time))
+                .build();
+    }
+}

--- a/src/main/java/uk/co/ramp/event/InfectionCreator.java
+++ b/src/main/java/uk/co/ramp/event/InfectionCreator.java
@@ -1,0 +1,79 @@
+package uk.co.ramp.event;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.co.ramp.Population;
+import uk.co.ramp.distribution.DistributionSampler;
+import uk.co.ramp.event.types.ImmutableInfectionEvent;
+import uk.co.ramp.event.types.InfectionEvent;
+import uk.co.ramp.io.InitialCaseReader;
+import uk.co.ramp.people.Case;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static uk.co.ramp.people.VirusStatus.EXPOSED;
+import static uk.co.ramp.people.VirusStatus.SUSCEPTIBLE;
+
+public class InfectionCreator {
+    private static final Logger LOGGER = LogManager.getLogger(InfectionCreator.class);
+
+    private final Population population;
+    private final DistributionSampler distributionSampler;
+    private final InitialCaseReader initialCaseReader;
+
+    public InfectionCreator(Population population, DistributionSampler distributionSampler, InitialCaseReader initialCaseReader) {
+        this.population = population;
+        this.distributionSampler = distributionSampler;
+        this.initialCaseReader = initialCaseReader;
+    }
+
+    List<InfectionEvent> createRandomInfections(int time, double randomInfectionRate, double randomCutoff) {
+        if (randomInfectionRate > 0d && time < randomCutoff) {
+            List<Case> sus = population.view().values().stream()
+                    .filter(aCase -> aCase.virusStatus() == SUSCEPTIBLE)
+                    .collect(Collectors.toList());
+
+            List<InfectionEvent> randomInfections = new ArrayList<>();
+            for (Case aCase : sus) {
+                if (distributionSampler.uniformBetweenZeroAndOne() < randomInfectionRate) {
+                    randomInfections.add(
+                            ImmutableInfectionEvent.builder().
+                                    time(time + 1).id(aCase.id()).
+                                    nextStatus(EXPOSED).
+                                    oldStatus(SUSCEPTIBLE).
+                                    exposedTime(time).
+                                    exposedBy(Case.getRandomInfection()).
+                                    build());
+                }
+            }
+
+            return randomInfections;
+        }
+        return List.of();
+    }
+
+    List<InfectionEvent> generateInitialInfections(int time) {
+        if (time == 0) {
+            Set<Integer> infectedIds = initialCaseReader.getCases();
+            List<InfectionEvent> virusEvents = new ArrayList<>();
+
+            InfectionEvent genericEvent = ImmutableInfectionEvent.builder().
+                    exposedBy(Case.getInitial()).
+                    oldStatus(SUSCEPTIBLE).
+                    nextStatus(EXPOSED).
+                    exposedTime(0).
+                    id(-1).
+                    time(0).build();
+
+            infectedIds.forEach(id -> virusEvents.add(ImmutableInfectionEvent.copyOf(genericEvent).withId(id)));
+
+            LOGGER.info("Generated initial outbreak of {} cases", virusEvents.size());
+
+            return virusEvents;
+        }
+        return List.of();
+    }
+}

--- a/src/main/java/uk/co/ramp/event/InfectionEventProcessor.java
+++ b/src/main/java/uk/co/ramp/event/InfectionEventProcessor.java
@@ -1,4 +1,4 @@
-package uk.co.ramp.event.processor;
+package uk.co.ramp.event;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -13,14 +13,12 @@ import static uk.co.ramp.people.VirusStatus.SUSCEPTIBLE;
 
 @Service
 public class InfectionEventProcessor extends CommonVirusEventProcessor<InfectionEvent> {
-    private final VirusEventProcessor virusEventProcessor;
     private final Population population;
 
     @Autowired
-    public InfectionEventProcessor(Population population, DiseaseProperties diseaseProperties, DistributionSampler distributionSampler, VirusEventProcessor virusEventProcessor) {
+    public InfectionEventProcessor(Population population, DiseaseProperties diseaseProperties, DistributionSampler distributionSampler) {
         super(population, diseaseProperties, distributionSampler);
         this.population = population;
-        this.virusEventProcessor = virusEventProcessor;
     }
 
     @Override
@@ -39,12 +37,11 @@ public class InfectionEventProcessor extends CommonVirusEventProcessor<Infection
                     oldStatus(event.nextStatus()).
                     nextStatus(nextStatus).
                     time(event.time() + deltaTime).
-                    eventProcessor(virusEventProcessor).
                     build();
 
             return ImmutableProcessedEventResult.builder()
-                    .addNewEvents(subsequentEvent)
-                    .completedEvent(event)
+                    .addNewVirusEvents(subsequentEvent)
+                    .addCompletedEvents(event)
                     .build();
         }
         return ImmutableProcessedEventResult.builder().build();

--- a/src/main/java/uk/co/ramp/event/LastContactTime.java
+++ b/src/main/java/uk/co/ramp/event/LastContactTime.java
@@ -1,0 +1,13 @@
+package uk.co.ramp.event;
+
+public class LastContactTime {
+    private final EventListGroup eventListGroup;
+
+    LastContactTime(EventListGroup eventListGroup) {
+        this.eventListGroup = eventListGroup;
+    }
+
+    public int get() {
+        return eventListGroup.lastContactTime();
+    }
+}

--- a/src/main/java/uk/co/ramp/event/ProcessedEventsGrouper.java
+++ b/src/main/java/uk/co/ramp/event/ProcessedEventsGrouper.java
@@ -1,0 +1,39 @@
+package uk.co.ramp.event;
+
+import uk.co.ramp.event.types.AlertEvent;
+import uk.co.ramp.event.types.ContactEvent;
+import uk.co.ramp.event.types.Event;
+import uk.co.ramp.event.types.ImmutableProcessedEventResult;
+import uk.co.ramp.event.types.InfectionEvent;
+import uk.co.ramp.event.types.ProcessedEventResult;
+import uk.co.ramp.event.types.VirusEvent;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class ProcessedEventsGrouper {
+    private <X extends Event> List<X> mapToList(List<ProcessedEventResult> combinedProcessedResults, Function<ProcessedEventResult, List<X>> newEventsFunc) {
+        return combinedProcessedResults.stream()
+                .map(newEventsFunc)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+
+    ProcessedEventResult groupProcessedEventResults(List<ProcessedEventResult> processedEventResults) {
+        List<AlertEvent> newAlertEvents = mapToList(processedEventResults, ProcessedEventResult::newAlertEvents);
+        List<ContactEvent> newContactEvents = mapToList(processedEventResults, ProcessedEventResult::newContactEvents);
+        List<InfectionEvent> newInfectionEvents = mapToList(processedEventResults, ProcessedEventResult::newInfectionEvents);
+        List<VirusEvent> newVirusEvents = mapToList(processedEventResults, ProcessedEventResult::newVirusEvents);
+        List<Event> completedEvents = mapToList(processedEventResults, ProcessedEventResult::completedEvents);
+
+        return ImmutableProcessedEventResult.builder()
+                .addAllNewAlertEvents(newAlertEvents)
+                .addAllNewContactEvents(newContactEvents)
+                .addAllNewInfectionEvents(newInfectionEvents)
+                .addAllNewVirusEvents(newVirusEvents)
+                .addAllCompletedEvents(completedEvents)
+                .build();
+    }
+}

--- a/src/main/java/uk/co/ramp/event/processor/EventProcessor.java
+++ b/src/main/java/uk/co/ramp/event/processor/EventProcessor.java
@@ -1,8 +1,0 @@
-package uk.co.ramp.event.processor;
-
-import uk.co.ramp.event.types.Event;
-import uk.co.ramp.event.types.ProcessedEventResult;
-
-public interface EventProcessor<T extends Event> {
-    ProcessedEventResult processEvent(T event);
-}

--- a/src/main/java/uk/co/ramp/event/types/AlertEvent.java
+++ b/src/main/java/uk/co/ramp/event/types/AlertEvent.java
@@ -3,7 +3,6 @@ package uk.co.ramp.event.types;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
-import uk.co.ramp.event.processor.AlertEventProcessor;
 import uk.co.ramp.people.AlertStatus;
 
 @Value.Immutable
@@ -16,10 +15,4 @@ public interface AlertEvent extends Event {
     AlertStatus nextStatus();
 
     AlertStatus oldStatus();
-
-    AlertEventProcessor eventProcessor();
-
-    default ProcessedEventResult processEvent() {
-        return eventProcessor().processEvent(this);
-    }
 }

--- a/src/main/java/uk/co/ramp/event/types/ContactEvent.java
+++ b/src/main/java/uk/co/ramp/event/types/ContactEvent.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
-import uk.co.ramp.event.processor.ContactEventProcessor;
 
 @Value.Immutable
 @JsonSerialize
@@ -20,10 +19,4 @@ public interface ContactEvent extends Event {
     double weight();
 
     String label();
-
-    ContactEventProcessor eventProcessor();
-
-    default ProcessedEventResult processEvent() {
-        return eventProcessor().processEvent(this);
-    }
 }

--- a/src/main/java/uk/co/ramp/event/types/Event.java
+++ b/src/main/java/uk/co/ramp/event/types/Event.java
@@ -1,8 +1,5 @@
 package uk.co.ramp.event.types;
 
 public interface Event {
-
     int time();
-
-    ProcessedEventResult processEvent();
 }

--- a/src/main/java/uk/co/ramp/event/types/EventProcessor.java
+++ b/src/main/java/uk/co/ramp/event/types/EventProcessor.java
@@ -1,0 +1,5 @@
+package uk.co.ramp.event.types;
+
+public interface EventProcessor<T extends Event> {
+    ProcessedEventResult processEvent(T event);
+}

--- a/src/main/java/uk/co/ramp/event/types/EventRunner.java
+++ b/src/main/java/uk/co/ramp/event/types/EventRunner.java
@@ -1,0 +1,5 @@
+package uk.co.ramp.event.types;
+
+public interface EventRunner {
+    void run(int time, double randomInfectionRate, double randomCutOff);
+}

--- a/src/main/java/uk/co/ramp/event/types/InfectionEvent.java
+++ b/src/main/java/uk/co/ramp/event/types/InfectionEvent.java
@@ -1,17 +1,10 @@
 package uk.co.ramp.event.types;
 
 import org.immutables.value.Value;
-import uk.co.ramp.event.processor.InfectionEventProcessor;
 
 @Value.Immutable
 public interface InfectionEvent extends CommonVirusEvent {
     int exposedBy();
 
     int exposedTime();
-
-    InfectionEventProcessor eventProcessor();
-
-    default ProcessedEventResult processEvent() {
-        return eventProcessor().processEvent(this);
-    }
 }

--- a/src/main/java/uk/co/ramp/event/types/PolicyEvent.java
+++ b/src/main/java/uk/co/ramp/event/types/PolicyEvent.java
@@ -9,9 +9,4 @@ import org.immutables.value.Value;
 @JsonDeserialize
 public interface PolicyEvent extends Event {
     // TODO will need to fill out
-
-    default ProcessedEventResult processEvent() {
-        throw new UnsupportedOperationException();
-    }
-
 }

--- a/src/main/java/uk/co/ramp/event/types/ProcessedEventResult.java
+++ b/src/main/java/uk/co/ramp/event/types/ProcessedEventResult.java
@@ -3,10 +3,12 @@ package uk.co.ramp.event.types;
 import org.immutables.value.Value.Immutable;
 
 import java.util.List;
-import java.util.Optional;
 
 @Immutable
 public interface ProcessedEventResult {
-    List<Event> newEvents();
-    Optional<Event> completedEvent();
+    List<AlertEvent> newAlertEvents();
+    List<ContactEvent> newContactEvents();
+    List<InfectionEvent> newInfectionEvents();
+    List<VirusEvent> newVirusEvents();
+    List<Event> completedEvents();
 }

--- a/src/main/java/uk/co/ramp/event/types/VirusEvent.java
+++ b/src/main/java/uk/co/ramp/event/types/VirusEvent.java
@@ -3,15 +3,9 @@ package uk.co.ramp.event.types;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
-import uk.co.ramp.event.processor.VirusEventProcessor;
 
 @Value.Immutable
 @JsonSerialize
 @JsonDeserialize
 public interface VirusEvent extends CommonVirusEvent {
-    VirusEventProcessor eventProcessor();
-
-    default ProcessedEventResult processEvent() {
-        return eventProcessor().processEvent(this);
-    }
 }

--- a/src/main/java/uk/co/ramp/io/ContactReader.java
+++ b/src/main/java/uk/co/ramp/io/ContactReader.java
@@ -2,9 +2,6 @@ package uk.co.ramp.io;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import uk.co.ramp.contact.ContactRecord;
-import uk.co.ramp.contact.ImmutableContactRecord;
-import uk.co.ramp.event.processor.ContactEventProcessor;
 import uk.co.ramp.event.types.ContactEvent;
 import uk.co.ramp.event.types.ImmutableContactEvent;
 import uk.co.ramp.io.csv.CsvReader;
@@ -13,44 +10,26 @@ import uk.co.ramp.io.types.StandardProperties;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
 public class ContactReader {
 
     private final StandardProperties properties;
-    private final ContactEventProcessor contactEventProcessor;
 
     @Autowired
-    public ContactReader(StandardProperties standardProperties, ContactEventProcessor contactEventProcessor) {
+    public ContactReader(StandardProperties standardProperties) {
         this.properties = standardProperties;
-        this.contactEventProcessor = contactEventProcessor;
     }
 
-    Map<Integer, List<ContactRecord>> readRecords(Reader reader) throws IOException {
+    public List<ContactEvent> readEvents(Reader reader) throws IOException {
 
-        List<ImmutableContactRecord> contactRecords = new CsvReader().read(reader, ImmutableContactRecord.class);
+        List<ImmutableContactEvent> contactEvents = new CsvReader().read(reader, ImmutableContactEvent.class);
 
-        return contactRecords.stream()
+        return contactEvents.stream()
                 .filter(event -> event.from() < properties.populationSize())
                 .filter(event -> event.to() < properties.populationSize())
                 .filter(event -> event.time() <= properties.timeLimit())
-                .collect(Collectors.groupingBy(ContactRecord::time));
-    }
-
-    public Map<Integer, List<ContactEvent>> readEvents(Reader reader) throws IOException {
-        Map<Integer, List<ContactRecord>> contactRecords = readRecords(reader);
-        return contactRecords.entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().stream()
-                        .map(record -> ImmutableContactEvent.builder()
-                                .time(record.time())
-                                .label(record.label())
-                                .weight(record.weight())
-                                .to(record.to())
-                                .from(record.from())
-                                .eventProcessor(contactEventProcessor)
-                                .build())
-                        .collect(Collectors.toList())));
+                .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/src/test/java/uk/co/ramp/ContactRunnerTest.java
+++ b/src/test/java/uk/co/ramp/ContactRunnerTest.java
@@ -3,8 +3,7 @@ package uk.co.ramp;
 import org.junit.*;
 import org.mockito.Mockito;
 import org.springframework.context.ApplicationContext;
-import uk.co.ramp.event.EventList;
-import uk.co.ramp.event.FormattedEventFactory;
+import uk.co.ramp.event.EventListGroup;
 import uk.co.ramp.event.types.ContactEvent;
 import uk.co.ramp.io.CompartmentWriter;
 import uk.co.ramp.io.ContactReader;
@@ -57,6 +56,7 @@ public class ContactRunnerTest {
         ContactReader reader = Mockito.mock(ContactReader.class);
         CompartmentWriter compartmentWriter = Mockito.mock(CompartmentWriter.class);
         InputFiles inputFiles = Mockito.mock(InputFiles.class);
+        EventListGroup eventListGroup = Mockito.mock(EventListGroup.class);
 
         // provide junk file for reader
         File temp = File.createTempFile("test", "file");
@@ -64,17 +64,19 @@ public class ContactRunnerTest {
 
         // empty map returns
         Map<Integer, Case> testData = new HashMap<>();
-        Map<Integer, List<ContactEvent>> testData2 = new HashMap<>();
+        List<ContactEvent> testData2 = new ArrayList<>();
 
 
         // inner behaviour
         when(reader.readEvents(any())).thenReturn(testData2);
         when(populationGenerator.generate()).thenReturn(testData);
 
+        when(eventListGroup.lastContactTime()).thenReturn(10);
+
         // setting context
         when(applicationContext.getBean(PopulationGenerator.class)).thenReturn(populationGenerator);
         when(applicationContext.getBean(ContactReader.class)).thenReturn(reader);
-        when(applicationContext.getBean(EventList.class)).thenReturn(new EventList(new FormattedEventFactory()));
+        when(applicationContext.getBean(EventListGroup.class)).thenReturn(eventListGroup);
         when(applicationContext.getBean(Outbreak.class)).thenReturn(outbreak);
         when(applicationContext.getBean(CompartmentWriter.class)).thenReturn(compartmentWriter);
 

--- a/src/test/java/uk/co/ramp/event/CommonVirusEventProcessorTest.java
+++ b/src/test/java/uk/co/ramp/event/CommonVirusEventProcessorTest.java
@@ -1,4 +1,4 @@
-package uk.co.ramp.event.processor;
+package uk.co.ramp.event;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -65,17 +65,17 @@ public class CommonVirusEventProcessorTest {
 
     @Test
     public void determineNextStatus() {
-        CommonVirusEvent commonVirusEvent = ImmutableVirusEvent.builder().id(0).oldStatus(EXPOSED).nextStatus(EXPOSED).time(1).eventProcessor(mock(VirusEventProcessor.class)).build();
+        CommonVirusEvent commonVirusEvent = ImmutableVirusEvent.builder().id(0).oldStatus(EXPOSED).nextStatus(EXPOSED).time(1).build();
         VirusStatus var = eventProcessor.determineNextStatus(commonVirusEvent);
 
         Assert.assertTrue(EXPOSED.getValidTransitions().contains(var));
 
-        commonVirusEvent = ImmutableVirusEvent.builder().id(0).oldStatus(EXPOSED).nextStatus(SYMPTOMATIC).time(1).eventProcessor(mock(VirusEventProcessor.class)).build();
+        commonVirusEvent = ImmutableVirusEvent.builder().id(0).oldStatus(EXPOSED).nextStatus(SYMPTOMATIC).time(1).build();
         var = eventProcessor.determineNextStatus(commonVirusEvent);
 
         Assert.assertTrue(SYMPTOMATIC.getValidTransitions().contains(var));
 
-        commonVirusEvent = ImmutableVirusEvent.builder().id(0).oldStatus(EXPOSED).nextStatus(SEVERELY_SYMPTOMATIC).time(1).eventProcessor(mock(VirusEventProcessor.class)).build();
+        commonVirusEvent = ImmutableVirusEvent.builder().id(0).oldStatus(EXPOSED).nextStatus(SEVERELY_SYMPTOMATIC).time(1).build();
         var = eventProcessor.determineNextStatus(commonVirusEvent);
 
         Assert.assertTrue(SEVERELY_SYMPTOMATIC.getValidTransitions().contains(var));

--- a/src/test/java/uk/co/ramp/event/ContactEventProcessorTest.java
+++ b/src/test/java/uk/co/ramp/event/ContactEventProcessorTest.java
@@ -1,4 +1,4 @@
-package uk.co.ramp.event.processor;
+package uk.co.ramp.event;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -11,10 +11,12 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.co.ramp.*;
+import uk.co.ramp.distribution.DistributionSampler;
 import uk.co.ramp.event.types.*;
 import uk.co.ramp.io.types.DiseaseProperties;
 import uk.co.ramp.people.Case;
 import uk.co.ramp.people.Human;
+import uk.co.ramp.policy.IsolationPolicy;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,13 +34,11 @@ public class ContactEventProcessorTest {
     @Rule
     public LogSpy logSpy = new LogSpy();
 
-    @Autowired
     private ContactEventProcessor eventProcessor;
 
     @Before
     public void setUp() throws Exception {
         DiseaseProperties diseaseProperties = TestUtils.diseaseProperties();
-        ReflectionTestUtils.setField(eventProcessor, "diseaseProperties", diseaseProperties);
 
         Human human = mock(Human.class);
         when(human.health()).thenReturn(-1d);
@@ -46,7 +46,11 @@ public class ContactEventProcessorTest {
 
         Map<Integer, Case> population = new HashMap<>();
         population.put(0, aCase);
-        ReflectionTestUtils.setField(eventProcessor, "population", new Population(population));
+
+        DistributionSampler distributionSampler = mock(DistributionSampler.class);
+        IsolationPolicy isolationPolicy = mock(IsolationPolicy.class);
+
+        eventProcessor = new ContactEventProcessor(new Population(population), diseaseProperties, distributionSampler, isolationPolicy);
     }
 
     @Test
@@ -70,7 +74,7 @@ public class ContactEventProcessorTest {
         population.put(1, mock1);
         ReflectionTestUtils.setField(eventProcessor, "population", new Population(population));
 
-        ContactEvent contactEvent = ImmutableContactEvent.builder().from(infector).to(infectee).time(time).weight(5000).label("").eventProcessor(eventProcessor).build();
+        ContactEvent contactEvent = ImmutableContactEvent.builder().from(infector).to(infectee).time(time).weight(5000).label("").build();
 
         Optional<InfectionEvent> var = eventProcessor.evaluateContact(contactEvent, 0);
 
@@ -105,7 +109,7 @@ public class ContactEventProcessorTest {
         ReflectionTestUtils.setField(eventProcessor, "population", new Population(population));
 
         // outer empty return
-        ContactEvent contactEvent = ImmutableContactEvent.builder().from(infector).to(infectee).time(time).weight(5000).label("").eventProcessor(eventProcessor).build();
+        ContactEvent contactEvent = ImmutableContactEvent.builder().from(infector).to(infectee).time(time).weight(5000).label("").build();
 
         Optional<InfectionEvent> var = eventProcessor.evaluateExposures(contactEvent, time);
 
@@ -141,7 +145,7 @@ public class ContactEventProcessorTest {
         ReflectionTestUtils.setField(eventProcessor, "population", new Population(population));
 
         // outer empty return
-        ContactEvent contactEvent = ImmutableContactEvent.builder().from(infector).to(infectee).time(time).weight(5000).label("").eventProcessor(eventProcessor).build();
+        ContactEvent contactEvent = ImmutableContactEvent.builder().from(infector).to(infectee).time(time).weight(5000).label("").build();
 
         Optional<InfectionEvent> var = eventProcessor.evaluateExposures(contactEvent, time);
 
@@ -173,12 +177,13 @@ public class ContactEventProcessorTest {
 
         ReflectionTestUtils.setField(eventProcessor, "population", new Population(population));
 
-        ContactEvent event = ImmutableContactEvent.builder().time(0).to(0).from(1).weight(50000).label("").eventProcessor(eventProcessor).build();
+        ContactEvent event = ImmutableContactEvent.builder().time(0).to(0).from(1).weight(50000).label("").build();
 
         ProcessedEventResult processedEventResult = eventProcessor.processEvent(event);
 
-        Assert.assertEquals(1, processedEventResult.newEvents().size());
-        InfectionEvent evnt = (InfectionEvent) processedEventResult.newEvents().get(0);
+        Assert.assertEquals(1, processedEventResult.newInfectionEvents().size());
+        Assert.assertEquals(1, processedEventResult.completedEvents().size());
+        InfectionEvent evnt = processedEventResult.newInfectionEvents().get(0);
 
         Assert.assertEquals(1, evnt.time());
         Assert.assertEquals(0, evnt.id());

--- a/src/test/java/uk/co/ramp/event/EventRunnerImplTest.java
+++ b/src/test/java/uk/co/ramp/event/EventRunnerImplTest.java
@@ -1,0 +1,144 @@
+package uk.co.ramp.event;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.co.ramp.event.types.AlertEvent;
+import uk.co.ramp.event.types.ContactEvent;
+import uk.co.ramp.event.types.Event;
+import uk.co.ramp.event.types.EventProcessor;
+import uk.co.ramp.event.types.ImmutableProcessedEventResult;
+import uk.co.ramp.event.types.InfectionEvent;
+import uk.co.ramp.event.types.ProcessedEventResult;
+import uk.co.ramp.event.types.VirusEvent;
+
+import java.util.List;
+
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class EventRunnerImplTest {
+    private EventProcessorRunner<AlertEvent> alertEventRunner;
+    private EventProcessorRunner<ContactEvent> contactEventRunner;
+    private EventProcessorRunner<InfectionEvent> infectionEventRunner;
+    private EventProcessorRunner<VirusEvent> virusEventRunner;
+    private ProcessedEventsGrouper processedEventsGrouper;
+    private InfectionCreator infectionCreator;
+    private EventListGroup eventListGroup;
+
+    private static class MockAlertEventProcessorRunner extends EventProcessorRunner<AlertEvent> {
+        public MockAlertEventProcessorRunner(EventProcessor<AlertEvent> eventProcessor, ProcessedEventsGrouper processedEventsGrouper) {
+            super(eventProcessor, processedEventsGrouper);
+        }
+    }
+
+    private static class MockContactEventProcessorRunner extends EventProcessorRunner<ContactEvent> {
+        public MockContactEventProcessorRunner(EventProcessor<ContactEvent> eventProcessor, ProcessedEventsGrouper processedEventsGrouper) {
+            super(eventProcessor, processedEventsGrouper);
+        }
+    }
+
+    private static class MockInfectionEventProcessorRunner extends EventProcessorRunner<InfectionEvent> {
+        public MockInfectionEventProcessorRunner(EventProcessor<InfectionEvent> eventProcessor, ProcessedEventsGrouper processedEventsGrouper) {
+            super(eventProcessor, processedEventsGrouper);
+        }
+    }
+
+    private static class MockVirusEventProcessorRunner extends EventProcessorRunner<VirusEvent> {
+        public MockVirusEventProcessorRunner(EventProcessor<VirusEvent> eventProcessor, ProcessedEventsGrouper processedEventsGrouper) {
+            super(eventProcessor, processedEventsGrouper);
+        }
+    }
+
+    private AlertEvent mockAlertEvent3;
+    private AlertEvent mockAlertEvent4;
+    private ContactEvent mockContactEvent3;
+    private ContactEvent mockContactEvent4;
+    private InfectionEvent mockInfectionEvent3;
+    private InfectionEvent mockInfectionEvent4;
+    private VirusEvent mockVirusEvent3;
+    private VirusEvent mockVirusEvent4;
+
+    private Event completedEvent1;
+    private Event completedEvent2;
+
+    @Before
+    public void setUp() {
+        this.alertEventRunner = mock(MockAlertEventProcessorRunner.class);
+        this.contactEventRunner = mock(MockContactEventProcessorRunner.class);
+        this.infectionEventRunner = mock(MockInfectionEventProcessorRunner.class);
+        this.virusEventRunner = mock(MockVirusEventProcessorRunner.class);
+        this.processedEventsGrouper = mock(ProcessedEventsGrouper.class);
+        this.infectionCreator = mock(InfectionCreator.class);
+        this.eventListGroup = mock(EventListGroup.class);
+        var mockAlertEvent1 = mock(AlertEvent.class);
+        var mockAlertEvent2 = mock(AlertEvent.class);
+        this.mockAlertEvent3 = mock(AlertEvent.class);
+        this.mockAlertEvent4 = mock(AlertEvent.class);
+        var mockContactEvent1 = mock(ContactEvent.class);
+        var mockContactEvent2 = mock(ContactEvent.class);
+        this.mockContactEvent3 = mock(ContactEvent.class);
+        this.mockContactEvent4 = mock(ContactEvent.class);
+        var mockInfectionEvent1 = mock(InfectionEvent.class);
+        var mockInfectionEvent2 = mock(InfectionEvent.class);
+        this.mockInfectionEvent3 = mock(InfectionEvent.class);
+        this.mockInfectionEvent4 = mock(InfectionEvent.class);
+        var mockInfectionEvent5 = mock(InfectionEvent.class);
+        var mockInfectionEvent6 = mock(InfectionEvent.class);
+        var mockVirusEvent1 = mock(VirusEvent.class);
+        var mockVirusEvent2 = mock(VirusEvent.class);
+        this.mockVirusEvent3 = mock(VirusEvent.class);
+        this.mockVirusEvent4 = mock(VirusEvent.class);
+        var mockProcessedAlertEventValue1 = mock(ProcessedEventResult.class);
+        var mockProcessedAlertEventValue2 = mock(ProcessedEventResult.class);
+        var mockProcessedAlertEventValue3 = mock(ProcessedEventResult.class);
+        var mockProcessedAlertEventValue4 = mock(ProcessedEventResult.class);
+        var mockAggregatedProcessedEvent = mock(ProcessedEventResult.class);
+        this.completedEvent1 = mock(Event.class);
+        this.completedEvent2 = mock(Event.class);
+
+        var alertEvents = List.of(mockAlertEvent1, mockAlertEvent2);
+        var contactEvents = List.of(mockContactEvent1, mockContactEvent2);
+        var infectionEvents = List.of(mockInfectionEvent1, mockInfectionEvent2);
+        var virusEvents = List.of(mockVirusEvent1, mockVirusEvent2);
+
+        when(eventListGroup.getAlertEvents(eq(0))).thenReturn(alertEvents);
+        when(eventListGroup.getContactEvents(eq(0))).thenReturn(contactEvents);
+        when(eventListGroup.getInfectionEvents(eq(0))).thenReturn(infectionEvents);
+        when(eventListGroup.getVirusEvents(eq(0))).thenReturn(virusEvents);
+
+        when(infectionCreator.generateInitialInfections(eq(0))).thenReturn(List.of(mockInfectionEvent5));
+        when(infectionCreator.createRandomInfections(eq(0), eq(0D), eq(0D))).thenReturn(List.of(mockInfectionEvent6));
+
+        when(alertEventRunner.run(eq(alertEvents))).thenReturn(mockProcessedAlertEventValue1);
+        when(contactEventRunner.run(eq(contactEvents))).thenReturn(mockProcessedAlertEventValue2);
+        when(infectionEventRunner.run(eq(infectionEvents))).thenReturn(mockProcessedAlertEventValue3);
+        when(virusEventRunner.run(eq(virusEvents))).thenReturn(mockProcessedAlertEventValue4);
+
+        when(mockAggregatedProcessedEvent.newAlertEvents()).thenReturn(List.of(mockAlertEvent3, mockAlertEvent4));
+        when(mockAggregatedProcessedEvent.newContactEvents()).thenReturn(List.of(mockContactEvent3, mockContactEvent4));
+        when(mockAggregatedProcessedEvent.newInfectionEvents()).thenReturn(List.of(mockInfectionEvent3, mockInfectionEvent4));
+        when(mockAggregatedProcessedEvent.newVirusEvents()).thenReturn(List.of(mockVirusEvent3, mockVirusEvent4));
+        when(mockAggregatedProcessedEvent.completedEvents()).thenReturn(List.of(completedEvent1, completedEvent2));
+
+        var initialInfections = ImmutableProcessedEventResult.builder().addNewInfectionEvents(mockInfectionEvent5).build();
+        var randomInfections = ImmutableProcessedEventResult.builder().addNewInfectionEvents(mockInfectionEvent6).build();
+        var processedEvents = List.of(initialInfections, mockProcessedAlertEventValue1, mockProcessedAlertEventValue2, mockProcessedAlertEventValue3, mockProcessedAlertEventValue4, randomInfections);
+        when(processedEventsGrouper.groupProcessedEventResults(eq(processedEvents))).thenReturn(mockAggregatedProcessedEvent);
+    }
+
+    @Test
+    public void testRun() {
+        EventRunnerImpl eventRunner = new EventRunnerImpl(alertEventRunner, contactEventRunner, infectionEventRunner, virusEventRunner, processedEventsGrouper, infectionCreator, eventListGroup);
+
+        eventRunner.run(0, 0, 0);
+
+        verify(eventListGroup).addContactEvents(List.of(mockContactEvent3, mockContactEvent4));
+        verify(eventListGroup).addInfectionEvents(List.of(mockInfectionEvent3, mockInfectionEvent4));
+        verify(eventListGroup).addAlertEvents(List.of(mockAlertEvent3, mockAlertEvent4));
+        verify(eventListGroup).addVirusEvents(List.of(mockVirusEvent3, mockVirusEvent4));
+        verify(eventListGroup).completed(List.of(completedEvent1, completedEvent2));
+    }
+
+}

--- a/src/test/java/uk/co/ramp/event/FormattedEventFactoryTest.java
+++ b/src/test/java/uk/co/ramp/event/FormattedEventFactoryTest.java
@@ -6,7 +6,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import uk.co.ramp.LogSpy;
 import uk.co.ramp.TestUtils;
-import uk.co.ramp.event.processor.*;
 import uk.co.ramp.event.types.*;
 import uk.co.ramp.people.AlertStatus;
 import uk.co.ramp.people.Case;
@@ -35,7 +34,7 @@ public class FormattedEventFactoryTest {
         VirusStatus old = VirusStatus.EXPOSED;
         VirusStatus next = VirusStatus.PRESYMPTOMATIC;
 
-        VirusEvent virusEvent = ImmutableVirusEvent.builder().time(time).id(id).oldStatus(old).nextStatus(next).eventProcessor(mock(VirusEventProcessor.class)).build();
+        VirusEvent virusEvent = ImmutableVirusEvent.builder().time(time).id(id).oldStatus(old).nextStatus(next).build();
 
         ImmutableFormattedEvent formatted = formattedEventFactory.create(virusEvent);
 
@@ -57,8 +56,7 @@ public class FormattedEventFactoryTest {
         VirusStatus old = VirusStatus.SUSCEPTIBLE;
         VirusStatus next = VirusStatus.EXPOSED;
 
-        InfectionEventProcessor eventProcessor = mock(InfectionEventProcessor.class);
-        InfectionEvent infectionEvent = ImmutableInfectionEvent.builder().time(time).id(id).oldStatus(old).nextStatus(next).exposedBy(exposer).exposedTime(exposedTime).eventProcessor(eventProcessor).build();
+        InfectionEvent infectionEvent = ImmutableInfectionEvent.builder().time(time).id(id).oldStatus(old).nextStatus(next).exposedBy(exposer).exposedTime(exposedTime).build();
 
         ImmutableFormattedEvent formatted = formattedEventFactory.create(infectionEvent);
 
@@ -102,7 +100,7 @@ public class FormattedEventFactoryTest {
 
         AlertEventProcessor eventProcessor = mock(AlertEventProcessor.class);
 
-        AlertEvent alertEvent = ImmutableAlertEvent.builder().time(time).id(id).nextStatus(next).oldStatus(old).eventProcessor(eventProcessor).build();
+        AlertEvent alertEvent = ImmutableAlertEvent.builder().time(time).id(id).nextStatus(next).oldStatus(old).build();
 
         ImmutableFormattedEvent formatted = formattedEventFactory.create(alertEvent);
 
@@ -119,9 +117,7 @@ public class FormattedEventFactoryTest {
         double weight = random.nextDouble() * random.nextInt(100);
         String label = RandomString.make(20);
 
-        ContactEventProcessor eventProcessor = mock(ContactEventProcessor.class);
-
-        ContactEvent contactEvent = ImmutableContactEvent.builder().time(time).to(id).from(id2).weight(weight).label(label).eventProcessor(eventProcessor).build();
+        ContactEvent contactEvent = ImmutableContactEvent.builder().time(time).to(id).from(id2).weight(weight).label(label).build();
 
         ImmutableFormattedEvent formatted = formattedEventFactory.create(contactEvent);
 
@@ -154,11 +150,11 @@ public class FormattedEventFactoryTest {
         VirusStatus nextVirus = VirusStatus.EXPOSED;
 
 
-        Event contactEvent = ImmutableContactEvent.builder().time(time).to(id).from(id2).weight(weight).label(label).eventProcessor(mock(ContactEventProcessor.class)).build();
+        Event contactEvent = ImmutableContactEvent.builder().time(time).to(id).from(id2).weight(weight).label(label).build();
         Event policyEvent = ImmutablePolicyEvent.builder().time(time).build();
-        Event alertEvent = ImmutableAlertEvent.builder().time(time).id(id).nextStatus(nextAlert).oldStatus(oldAlert).eventProcessor(mock(AlertEventProcessor.class)).build();
-        Event infectionEvent = ImmutableInfectionEvent.builder().time(time).id(id).oldStatus(oldVirus).nextStatus(nextVirus).exposedBy(exposer).exposedTime(exposedTime).eventProcessor(mock(InfectionEventProcessor.class)).build();
-        Event virusEvent = ImmutableVirusEvent.builder().time(time).id(id).oldStatus(oldVirus).nextStatus(nextVirus).eventProcessor(mock(VirusEventProcessor.class)).build();
+        Event alertEvent = ImmutableAlertEvent.builder().time(time).id(id).nextStatus(nextAlert).oldStatus(oldAlert).build();
+        Event infectionEvent = ImmutableInfectionEvent.builder().time(time).id(id).oldStatus(oldVirus).nextStatus(nextVirus).exposedBy(exposer).exposedTime(exposedTime).build();
+        Event virusEvent = ImmutableVirusEvent.builder().time(time).id(id).oldStatus(oldVirus).nextStatus(nextVirus).build();
         Event notCovered = mock(CommonVirusEvent.class);
 
         // TODO: not printing these as they're an input... should discuss with group.

--- a/src/test/java/uk/co/ramp/event/InfectionCreatorTest.java
+++ b/src/test/java/uk/co/ramp/event/InfectionCreatorTest.java
@@ -1,0 +1,50 @@
+package uk.co.ramp.event;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.co.ramp.Population;
+import uk.co.ramp.distribution.DistributionSampler;
+import uk.co.ramp.event.types.InfectionEvent;
+import uk.co.ramp.io.InitialCaseReader;
+import uk.co.ramp.people.Case;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.co.ramp.people.VirusStatus.SUSCEPTIBLE;
+
+public class InfectionCreatorTest {
+    private DistributionSampler distributionSampler;
+    private InitialCaseReader initialCaseReader;
+
+    @Before
+    public void setUp() {
+        distributionSampler = mock(DistributionSampler.class);
+        var distributionValues = List.of(0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.95);
+        var counter = new AtomicInteger(0);
+        when(distributionSampler.uniformBetweenZeroAndOne()).thenAnswer(i -> distributionValues.get(counter.incrementAndGet() % distributionValues.size()));
+        initialCaseReader = mock(InitialCaseReader.class);
+    }
+    @Test
+    public void createRandomInfections() {
+
+        Map<Integer, Case> population = new HashMap<>();
+        for (int i = 0; i < 100; i++) {
+            Case mock0 = mock(Case.class);
+            when(mock0.virusStatus()).thenReturn(SUSCEPTIBLE);
+            when(mock0.id()).thenReturn(i);
+            population.put(i, mock0);
+        }
+        InfectionCreator infectionCreator = new InfectionCreator(new Population(population), distributionSampler, initialCaseReader);
+
+        List<InfectionEvent> list = infectionCreator.createRandomInfections(0, 0.1, 100);
+
+        assertThat(list.size()).isEqualTo(10);
+    }
+
+}

--- a/src/test/java/uk/co/ramp/event/VirusEventProcessorTest.java
+++ b/src/test/java/uk/co/ramp/event/VirusEventProcessorTest.java
@@ -1,4 +1,4 @@
-package uk.co.ramp.event.processor;
+package uk.co.ramp.event;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -51,18 +51,18 @@ public class VirusEventProcessorTest {
         Map<Integer, Case> population = new HashMap<>();
         population.put(0, aCase);
 
-        this.eventProcessor = new VirusEventProcessor(new Population(population), diseaseProperties, distributionSampler, mock(AlertEventProcessor.class));
+        this.eventProcessor = new VirusEventProcessor(new Population(population), diseaseProperties, distributionSampler);
     }
 
     @Test
     public void checkForAlert() {
 
-        VirusEvent virusEvent = ImmutableVirusEvent.builder().id(0).oldStatus(EXPOSED).nextStatus(PRESYMPTOMATIC).time(1).eventProcessor(eventProcessor).build();
+        VirusEvent virusEvent = ImmutableVirusEvent.builder().id(0).oldStatus(EXPOSED).nextStatus(PRESYMPTOMATIC).time(1).build();
 
         Assert.assertTrue(eventProcessor.checkForAlert(virusEvent).isEmpty());
         int time = 1;
         int id = 0;
-        virusEvent = ImmutableVirusEvent.builder().id(id).oldStatus(PRESYMPTOMATIC).nextStatus(SYMPTOMATIC).time(time).eventProcessor(eventProcessor).build();
+        virusEvent = ImmutableVirusEvent.builder().id(id).oldStatus(PRESYMPTOMATIC).nextStatus(SYMPTOMATIC).time(time).build();
 
         Optional<AlertEvent> var = eventProcessor.checkForAlert(virusEvent);
 
@@ -91,13 +91,17 @@ public class VirusEventProcessorTest {
 
         ReflectionTestUtils.setField(eventProcessor, "population", new Population(population));
 
-        VirusEvent event = ImmutableVirusEvent.builder().time(0).id(0).oldStatus(EXPOSED).nextStatus(ASYMPTOMATIC).eventProcessor(eventProcessor).build();
+        VirusEvent event = ImmutableVirusEvent.builder().time(0).id(0).oldStatus(EXPOSED).nextStatus(ASYMPTOMATIC).build();
 
         ProcessedEventResult processedEventResult = eventProcessor.processEvent(event);
 
-        Assert.assertEquals(1, processedEventResult.newEvents().size());
-        Assert.assertTrue(processedEventResult.newEvents().get(0) instanceof VirusEvent);
-        VirusEvent evnt = (VirusEvent) processedEventResult.newEvents().get(0);
+        Assert.assertEquals(1, processedEventResult.newVirusEvents().size());
+        Assert.assertEquals(0, processedEventResult.newAlertEvents().size());
+        Assert.assertEquals(0, processedEventResult.newContactEvents().size());
+        Assert.assertEquals(0, processedEventResult.newInfectionEvents().size());
+        Assert.assertEquals(1, processedEventResult.completedEvents().size());
+
+        VirusEvent evnt = processedEventResult.newVirusEvents().get(0);
 
         Assert.assertEquals(diseaseProperties.timeLatent().mean(), evnt.time());
         Assert.assertEquals(0, evnt.id());

--- a/src/test/java/uk/co/ramp/utilities/ContactReaderTest.java
+++ b/src/test/java/uk/co/ramp/utilities/ContactReaderTest.java
@@ -1,9 +1,6 @@
 package uk.co.ramp.utilities;
 
 import org.junit.Test;
-import uk.co.ramp.contact.ContactRecord;
-import uk.co.ramp.contact.ImmutableContactRecord;
-import uk.co.ramp.event.processor.ContactEventProcessor;
 import uk.co.ramp.event.types.ContactEvent;
 import uk.co.ramp.event.types.ImmutableContactEvent;
 import uk.co.ramp.io.ContactReader;
@@ -32,14 +29,12 @@ public class ContactReaderTest {
             .steadyState(true)
             .build();
 
-    private ContactEventProcessor eventProcessor = mock(ContactEventProcessor.class);
     private final ContactEvent record1 = ImmutableContactEvent.builder()
             .time(0)
             .from(8)
             .to(9)
             .weight(6.7)
             .label("label")
-            .eventProcessor(eventProcessor)
             .build();
 
     private final ContactEvent record2 = ImmutableContactEvent.builder()
@@ -48,16 +43,14 @@ public class ContactReaderTest {
             .to(8)
             .weight(8.2)
             .label("label")
-            .eventProcessor(eventProcessor)
             .build();
 
     @Test
     public void testRead() throws IOException {
         StringReader stringReader = new StringReader(csv);
-        Map<Integer, List<ContactEvent>> dailyContactRecords = new ContactReader(properties, eventProcessor).readEvents(stringReader);
+        List<ContactEvent> dailyContactRecords = new ContactReader(properties).readEvents(stringReader);
 
-        assertThat(dailyContactRecords).containsOnlyKeys(0);
-        assertThat(dailyContactRecords.get(0)).containsExactly(record1, record2);
+        assertThat(dailyContactRecords).containsExactly(record1, record2);
     }
 
 
@@ -69,7 +62,7 @@ public class ContactReaderTest {
                 "2,10000,10001,8.2, label\n";
         StringReader stringReader = new StringReader(csvOverPersonLimit);
 
-        Map<Integer, List<ContactEvent>> dailyContactRecords = new ContactReader(properties, eventProcessor).readEvents(stringReader);
+        List<ContactEvent> dailyContactRecords = new ContactReader(properties).readEvents(stringReader);
 
         assertThat(dailyContactRecords).isEmpty();
     }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -3,7 +3,7 @@
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
     <logger name="uk.co.ramp.Outbreak" level="debug"/>
     <logger name="uk.co.ramp.event.EventProcessorRunner" level="debug"/>
-    <logger name="uk.co.ramp.event.processor.ContactEventProcessor" level="debug"/>
+    <logger name="uk.co.ramp.event.ContactEventProcessor" level="debug"/>
     <logger name="org.springframework.core " level="error"/>
     <logger name="org.springframework.beans" level="error"/>
     <logger name="org.springframework.context" level="error"/>


### PR DESCRIPTION
One more refactor PR: Splitting up Event List into 4 event lists. One for each event type. 

No functional changes. 

Had to do this because we need to be able to extract all recent contact events for a given person when performing contact tracing. Therefore, we need to be able to extract the contact events form the event list. So I've split the logic so that there is an event list per event type. 

I will raise my functional changes PR for contact tracing once this is reviewed/merged.

Thanks
