### PR TITLE
Accounting for floating point error on the population distribution.

### DIFF
--- a/src/main/java/uk/co/ramp/io/types/PopulationProperties.java
+++ b/src/main/java/uk/co/ramp/io/types/PopulationProperties.java
@@ -19,8 +19,9 @@ public interface PopulationProperties {
 
   @Check
   default void check() {
+    final double eps = 1e-6;
     Preconditions.checkState(
-        populationDistribution().values().stream().mapToDouble(d -> d).sum() == 1,
+        Math.abs(populationDistribution().values().stream().mapToDouble(d -> d).sum() - 1.0) < eps,
         "Sum of population distribution should be 1");
     Preconditions.checkState(
         populationDistribution().keySet().equals(populationAges().keySet()),


### PR DESCRIPTION
For some random population distribution values exact matching of sum to be one leads termination of the run, due to the floating point approximation error. Here a small tolerance is introduced for preventing the termination during the repeated drawing of random population distributions in sensitivity analysis.