### PR TITLE
Record days spent in isolation only when leaving isolation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ apply plugin: 'application'
 apply plugin: 'java'
 apply plugin: 'jacoco'
 apply plugin: 'idea'
+apply plugin: 'eclipse'
 apply plugin: 'org.sonarqube'
 
 project.version = "1.0-SNAPSHOT"

--- a/src/main/java/uk/co/ramp/policy/isolation/SingleCaseIsolationPolicy.java
+++ b/src/main/java/uk/co/ramp/policy/isolation/SingleCaseIsolationPolicy.java
@@ -198,6 +198,14 @@ class SingleCaseIsolationPolicy {
         (threshold < requiredIsolationFactor)
             && (overrideComplianceAndForcePolicy || isCompliant)
             && (!timedPolicy || isInIsolationPeriod);
+    boolean wasIsolating = currentlyInIsolationMap.get(id) != null;
+
+    // record days spent in isolation when individual comes out of isolation
+    if (wasIsolating && !willIsolate) {
+      int duration = currentTime - currentlyInIsolationMap.get(id).startTime();
+      statisticsRecorder.recordDaysInIsolation(id, duration);
+    }
+
     if (timedPolicy || isDefaultPolicy) {
       currentlyInIsolationMap.compute(
           id,
@@ -207,9 +215,6 @@ class SingleCaseIsolationPolicy {
                       val, matchingIsolationProperty, startOfIsolationTime, requiredIsolationTime)
                   : null);
     }
-
-    if (willIsolate && requiredIsolationTime > 0)
-      statisticsRecorder.recordDaysInIsolation(id, requiredIsolationTime);
 
     return willIsolate;
   }

--- a/src/test/java/uk/co/ramp/io/InitialCaseReaderTest.java
+++ b/src/test/java/uk/co/ramp/io/InitialCaseReaderTest.java
@@ -77,8 +77,7 @@ public class InitialCaseReaderTest {
     Assert.assertThat(
         logSpy.getOutput(),
         containsString("An IOException was thrown while populating the initial cases."));
-    Assert.assertThat(
-        logSpy.getOutput(), containsString("This file doesn't exist (No such file or directory)"));
+    Assert.assertThat(logSpy.getOutput(), containsString("This file doesn't exist"));
     Assert.assertThat(
         logSpy.getOutput(),
         containsString("The set of initial cases is 0 long, when 10 was requested"));


### PR DESCRIPTION
This is one of the changes that Sam made in his Isolation release PR, with a suggested very minor refactor.

statisticsRecorder.recordDaysInIsolation() was being called repeatedly while individuals were in isolation.  This changes it to only be called when individuals come out of isolation.  (Note: This change will mean that some days spent in isolation are not recorded, if anyone remains in isolation at the end of the simulation.)

This PR contains 3 commits, which could be reviewed separately.  The first two commits are minor changes to get the build working better on my laptop.
